### PR TITLE
Check an email is verified before setting it as primary.

### DIFF
--- a/multimail/views.py
+++ b/multimail/views.py
@@ -69,7 +69,7 @@ def set_as_primary(request, email_pk):
     """Set the requested email address as the primary. Can only be
     requested by the owner of the email address."""
     email = get_object_or_404(EmailAddress, pk=email_pk)
-    if email.is_verified():
+    if not email.is_verified():
         messages.error(request, 'Email %s needs to be verified first.' % email)
     if email.user != request.user:
         messages.error(request, 'Invalid request.')


### PR DESCRIPTION
I'm not sure if you want this as a feature but I think it's logic to think that an email should be verified first before setting it as primary.

Also this pull requests fix a stupid typo I did in my previous commits. I added messages.success and messages.error without passing the request as a parameter and that raises a TypeError.
