### PR TITLE
new option to choose whether User.is_active==True means verified or not

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,10 @@ MULTIMAIL_ALLOW_VERIFICATION_OF_INACTIVE_ACCOUNTS
     Default: False. Whether to allow users to verify emails associated
     with a deactivated account.
 
+MULTIMAIL_AUTOVERIFY_ACTIVE_ACCOUNTS
+    Default: True. Whether to verify accounts that have been set as active
+    outside of django-multimail.
+
 MULTIMAIL_DELETE_PRIMARY
     Default: False. Whether to clear the email field on the user object
     when the last EmailAddress is deleted.

--- a/multimail/models.py
+++ b/multimail/models.py
@@ -165,7 +165,8 @@ def email_address_handler(sender, **kwargs):
                 # Provides that an address that has been just verified
                 # without use of django-multimail, is still considered
                 # verified in conditions of django-multimail
-                if user.is_active and not addr.verified_at:
+                if MM.AUTOVERIFY_ACTIVE_ACCOUNTS and \
+                   user.is_active and not addr.verified_at:
                     addr.verified_at = now()
             except EmailAddress.DoesNotExist:
                 addr = EmailAddress()

--- a/multimail/settings.py
+++ b/multimail/settings.py
@@ -9,6 +9,7 @@ class Settings(dict):
 
 MM = Settings(
     ALLOW_VERIFICATION_OF_INACTIVE_ACCOUNTS = False,
+    AUTOVERIFY_ACTIVE_ACCOUNTS = True,
     DELETE_PRIMARY = False,
     VERIFICATION_LINK_SENT_MESSAGE = \
         _("A verification link has been sent to %(email)s"),


### PR DESCRIPTION
In my case, active users have an unverified e-mail until they verify (it makes sense). Therefore I made the _active means verified_ optional.
